### PR TITLE
[feat, refactor]: MarkdownRenderer 수정, Link 관련 수정

### DIFF
--- a/docs/projects/noLibApp.mdx
+++ b/docs/projects/noLibApp.mdx
@@ -5,7 +5,7 @@ skills: ['HTML', 'CSS', 'JavaScript', 'TypeScript']
 category: {type: 'project'}
 links: [{text: 'GitHub', href: 'https://github.com/17-sss/no-lib-App'}]
 thumbnail: '/docs/projects/noLibApp/thumbnail.png'
-summary: 'React와 같은 라이브러리의 도움 없이 SPA 만들기 (게시판 만들기)'
+summary: 'React와 같은 라이브러리의 도움 없이 SPA 만들기'
 ---
 
 - `HTML`, `CSS`, `JS` 와 `Webpack` 을 활용하여 **Single Page Application**를 제작합니다.

--- a/package.json
+++ b/package.json
@@ -50,10 +50,8 @@
     "react-icons": "^4.6.0",
     "react-transition-group": "^4.4.5",
     "rehype-slug": "^5.1.0",
-    "remark": "^14.0.2",
     "remark-gfm": "^3.0.1",
     "remark-html": "^15.0.1",
-    "remark-prism": "^1.3.6",
     "sharp": "^0.31.2",
     "styled-system": "^5.1.5",
     "typescript": "4.8.4"

--- a/pages/resume/index.stories.tsx
+++ b/pages/resume/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {ComponentStory, ComponentMeta} from '@storybook/react';
 
-import {PageLayout, sampleMDXData} from '@src/shared';
+import {codeblock, PageLayout, sampleMarkdown} from '@src/shared';
 
 import ResumePage from './index.page';
 
@@ -39,7 +39,6 @@ Default.args = {
     job: 'Engineer',
     email: 'email@email.com',
     introduce: ['INTRODUCE1', 'INTRODUCE2', 'INTRODUCE3'],
-    extension: '.mdx',
-    content: sampleMDXData,
+    content: `${sampleMarkdown}\n${codeblock}`,
   },
 };

--- a/ranolog.config.ts
+++ b/ranolog.config.ts
@@ -11,7 +11,7 @@ const defaultImage = '/profile_image.jpg';
 
 // [SEO & UTTERANC] =============================================
 export const metadata: DefaultSeoMeta = {
-  title: `Hoyoung | Frontend Engineer`,
+  title: 'Hoyoung - Frontend Engineer',
   description,
   image: defaultImage,
   url: siteUrl,

--- a/src/blog/components/BlogDetailTemplate.tsx
+++ b/src/blog/components/BlogDetailTemplate.tsx
@@ -40,7 +40,9 @@ const BlogDetailTemplate: React.FC<BlogDetailTemplateProps> = ({postDoc, postDoc
     <div css={containerCss} {...props}>
       <PostDetail
         css={postCss}
-        postDoc={currentDoc}
+        date={currentDoc.date}
+        subject={currentDoc.subject}
+        category={currentDoc.category}
         markdownRenderer={
           <MarkdownRenderer
             ref={updateMarkdownHtml}

--- a/src/blog/components/PostDetail/index.stories.tsx
+++ b/src/blog/components/PostDetail/index.stories.tsx
@@ -1,36 +1,46 @@
 import React from 'react';
 
 import {ComponentStory, ComponentMeta} from '@storybook/react';
+import {MDXRemoteSerializeResult} from 'next-mdx-remote';
 
-import {createPostDocsMock, sampleContentHtml, samplePrismHtml} from '@src/shared';
+import {createPostDocsMock, MarkdownRenderer} from '@src/shared';
 
-import PostDetail from './index';
+import PostDetail, {PostDetailProps} from './index';
+
+type PostDetailStoryType = React.FC<
+  Omit<PostDetailProps, 'markdownRenderer'> & {content: string | MDXRemoteSerializeResult}
+>;
 
 const storyDefault = {
   title: 'components/blog/PostDetail',
   component: PostDetail,
-} as ComponentMeta<typeof PostDetail>;
+  argTypes: {
+    markdownRenderer: {table: {disable: true}},
+  },
+} as ComponentMeta<PostDetailStoryType>;
 
 export default storyDefault;
 
-const Template: ComponentStory<typeof PostDetail> = (args) => {
-  return <PostDetail {...args} />;
+const Template: ComponentStory<PostDetailStoryType> = ({content, ...args}) => {
+  return <PostDetail {...args} markdownRenderer={<MarkdownRenderer content={content} />} />;
 };
 
-const postDoc = {
-  ...createPostDocsMock(1)[0],
-  content: `${sampleContentHtml}${samplePrismHtml}`,
-};
+const samplePost = (() => {
+  const {subject, date, category, content} = createPostDocsMock(1)[0];
+  return {subject, date, category, content};
+})();
 
 export const No_Category = Template.bind({});
-No_Category.args = {postDoc};
+No_Category.args = {...samplePost};
 
 export const Category = Template.bind({});
 Category.args = {
-  postDoc: {...postDoc, category: 'React'},
+  ...samplePost,
+  category: 'React',
 };
 
 export const Categories = Template.bind({});
 Categories.args = {
-  postDoc: {...postDoc, category: ['React', 'JavaScript', 'DO IT', 'SAMPLE', 'JUST']},
+  ...samplePost,
+  category: ['React', 'JavaScript', 'DO IT', 'SAMPLE', 'JUST'],
 };

--- a/src/blog/components/PostDetail/index.tsx
+++ b/src/blog/components/PostDetail/index.tsx
@@ -1,33 +1,37 @@
 import {useMemo} from 'react';
 
 import {createPostDateText} from '@src/blog';
-import {CustomCode, CssProp, PostDocument, systemCss} from '@src/shared';
+import {CustomCode, CssProp, systemCss, PostDocument} from '@src/shared';
 
-export interface PostDetailProps {
-  postDoc: PostDocument;
+export interface PostDetailProps extends Pick<PostDocument, 'subject' | 'date' | 'category'> {
   markdownRenderer: React.ReactNode;
 }
 
-const PostDetail: React.FC<PostDetailProps> = ({postDoc, markdownRenderer, ...props}) => {
+const PostDetail: React.FC<PostDetailProps> = ({
+  subject,
+  date,
+  category,
+  markdownRenderer,
+  ...props
+}) => {
   const categories = useMemo(() => {
-    const postCategories = postDoc.category;
-    if (!postCategories || (Array.isArray(postCategories) && postCategories.length === 0)) {
+    if (!category || (Array.isArray(category) && category.length === 0)) {
       return;
     }
-    if (typeof postCategories === 'string') {
-      return [postCategories];
+    if (typeof category === 'string') {
+      return [category];
     }
-    return postCategories;
-  }, [postDoc.category]);
+    return category;
+  }, [category]);
 
   const dateText = useMemo(() => {
-    return createPostDateText(postDoc.date);
-  }, [postDoc.date]);
+    return createPostDateText(date);
+  }, [date]);
 
   return (
     <div css={containerCss} {...props}>
       <div css={infoBoxCss}>
-        <p className="subject">{postDoc.subject}</p>
+        <p className="subject">{subject}</p>
         {categories && (
           <div css={categoryBoxCss}>
             {categories?.map((category, idx) => (

--- a/src/blog/components/TableContents/index.tsx
+++ b/src/blog/components/TableContents/index.tsx
@@ -1,6 +1,4 @@
-import Link from 'next/link';
-
-import {CssProp, systemCss} from '@src/shared';
+import {CssProp, CustomLink, systemCss} from '@src/shared';
 
 export interface TableContentItem {
   id: string;
@@ -20,9 +18,7 @@ const TableContents: React.FC<TableContentsProps> = ({contentItems, ...props}) =
       {contentItems.map((item) => {
         return (
           <li key={item.id}>
-            <Link href={item.href} passHref legacyBehavior>
-              <a>{item.text}</a>
-            </Link>
+            <CustomLink href={item.href}>{item.text}</CustomLink>
             {item.children.length > 0 && <TableContents contentItems={item.children} />}
           </li>
         );

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,14 +1,10 @@
 /** [!] 모두 page 컴포넌트에서만 사용됨  */
 import fs from 'fs';
 import matter from 'gray-matter';
-// @ts-ignore
-import mdxPrism from 'mdx-prism';
 import {MDXRemoteSerializeResult} from 'next-mdx-remote';
-import {serialize} from 'next-mdx-remote/serialize';
 import path from 'path';
-import rehypeSlug from 'rehype-slug';
-import remarkGfm from 'remark-gfm';
-import remarkHtml from 'remark-html';
+
+import {markdownToHtml} from '@src/shared';
 
 export interface DefaultDocument {
   id: string;
@@ -22,14 +18,6 @@ type SubFolderType = 'posts' | 'projects' | 'resumes';
 const REGEX_MARKDOWN = /\.mdx?$/;
 
 const docsDir = path.join(process.cwd(), 'docs');
-
-/** [async] Markdown Text -> HTML 변환 (MDX 포함) */
-export const markdownToHtml = async (content: string) => {
-  const result = await serialize(content, {
-    mdxOptions: {remarkPlugins: [remarkGfm, remarkHtml], rehypePlugins: [rehypeSlug, mdxPrism]},
-  });
-  return result;
-};
 
 /** [async] 모든 정적 데이터 가져옴  */
 export const getDocuments = async <TDoc extends DefaultDocument = DefaultDocument>(

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -7,17 +7,14 @@ import {MDXRemoteSerializeResult} from 'next-mdx-remote';
 import {serialize} from 'next-mdx-remote/serialize';
 import path from 'path';
 import rehypeSlug from 'rehype-slug';
-import {remark} from 'remark';
 import remarkGfm from 'remark-gfm';
 import remarkHtml from 'remark-html';
-import remarkPrism from 'remark-prism';
 
 export interface DefaultDocument {
   id: string;
   subject: string;
   date: string | {start: string; end?: string};
   content: string | MDXRemoteSerializeResult;
-  extension: string;
   summary?: string;
 }
 type SubFolderType = 'posts' | 'projects' | 'resumes';
@@ -26,30 +23,12 @@ const REGEX_MARKDOWN = /\.mdx?$/;
 
 const docsDir = path.join(process.cwd(), 'docs');
 
-/** [async] Markdown Text -> HTML 변환 */
-const markdownToHtml = async (content: string) => {
-  const result = await remark()
-    .use(remarkGfm)
-    .use(remarkHtml, {sanitize: false})
-    .use(rehypeSlug)
-    .use(remarkPrism)
-    .process(content);
-  return result.toString();
-};
-
-/** [async] Markdown Text -> HTML 변환 (for MDX) */
-const markdownToHtmlForMDX = async (content: string) => {
+/** [async] Markdown Text -> HTML 변환 (MDX 포함) */
+export const markdownToHtml = async (content: string) => {
   const result = await serialize(content, {
     mdxOptions: {remarkPlugins: [remarkGfm, remarkHtml], rehypePlugins: [rehypeSlug, mdxPrism]},
   });
   return result;
-};
-
-export const createMarkdownContent = async (content: string, extension?: string) => {
-  if (extension === '.mdx') {
-    return markdownToHtmlForMDX(content);
-  }
-  return await markdownToHtml(content);
 };
 
 /** [async] 모든 정적 데이터 가져옴  */
@@ -65,10 +44,9 @@ export const getDocuments = async <TDoc extends DefaultDocument = DefaultDocumen
       const fullPath = path.join(currentDir, fileName);
       const fileContents = fs.readFileSync(fullPath, 'utf8');
       const id = fileName.replace(REGEX_MARKDOWN, '');
-      const extension = fileName.match(REGEX_MARKDOWN)?.[0] ?? 'unknown';
       const matterResult = matter(fileContents);
-      const content = await createMarkdownContent(matterResult.content, extension);
-      result.push({...matterResult.data, id, content, extension} as TDoc);
+      const content = await markdownToHtml(matterResult.content);
+      result.push({...matterResult.data, id, content} as TDoc);
     }
   } catch (e) {
     console.error((e as Error).message);
@@ -126,10 +104,9 @@ export const getDocumentByFileName = async <TDoc extends DefaultDocument = Defau
     const fullPath = path.join(docsDir, subFolderType ?? '', fileName);
     const fileContents = fs.readFileSync(fullPath, 'utf8');
     const id = fileName.replace(REGEX_MARKDOWN, '');
-    const extension = fileName.match(REGEX_MARKDOWN)?.[0] ?? 'unknown';
     const matterResult = matter(fileContents);
-    const content = await createMarkdownContent(matterResult.content, extension);
-    return {...matterResult.data, id, content, extension} as TDoc;
+    const content = await markdownToHtml(matterResult.content);
+    return {...matterResult.data, id, content} as TDoc;
   } catch (e) {
     console.error((e as Error).message);
     return null;

--- a/src/main/components/MainTemplate.tsx
+++ b/src/main/components/MainTemplate.tsx
@@ -1,6 +1,8 @@
+import {FiChevronRight} from 'react-icons/fi';
+
 import {PostList} from '@src/blog';
 import {useMainTemplate, IntroduceBox, IntroduceBoxProps} from '@src/main';
-import {CssProp, systemCss, PostDocument, centerAlignedChildren} from '@src/shared';
+import {CssProp, systemCss, PostDocument, centerAlignedChildren, CustomLink} from '@src/shared';
 
 export interface MainTemplateProps {
   recentPosts: PostDocument[];
@@ -13,7 +15,11 @@ const MainTemplate: React.FC<MainTemplateProps> = ({recentPosts, introduceProps,
     <div css={containerCss} {...props}>
       <IntroduceBox {...introduceProps} />
       <div css={recentPostBoxCss}>
-        <p className="title">Recent Post</p>
+        <CustomLink css={recentPostLinkCss} href="/blog">
+          <span>Recent Post</span>
+          <FiChevronRight />
+        </CustomLink>
+
         {!isEmpty ? (
           <PostList postDocs={recentPosts} onPostClick={handlePostItemClick} />
         ) : (
@@ -32,15 +38,23 @@ const containerCss: CssProp = systemCss({
   },
 });
 
-const recentPostBoxCss: CssProp = (theme) =>
+const recentPostBoxCss: CssProp = systemCss({
+  '& > * + *': {
+    mt: '0.5rem',
+  },
+});
+
+const recentPostLinkCss: CssProp = (theme) =>
   systemCss({
-    '.title': {
-      fontSize: [theme.fontSizes.p24, theme.fontSizes.p28],
-      fontWeight: 600,
-      color: theme.colors.gray700,
-    },
-    '& > * + *': {
-      mt: '0.5rem',
+    display: 'inline-flex',
+    alignItems: 'center',
+    fontSize: [theme.fontSizes.p24, theme.fontSizes.p28],
+    fontWeight: 600,
+    color: theme.colors.gray700,
+    '@media (hover: hover) and (pointer: fine)': {
+      '&:hover': {
+        color: theme.colors.gray400,
+      },
     },
   });
 

--- a/src/projects/components/ProjectInfo/index.stories.tsx
+++ b/src/projects/components/ProjectInfo/index.stories.tsx
@@ -17,7 +17,11 @@ const Template: ComponentStory<typeof ProjectInfo> = (args) => {
   return <ProjectInfo {...args} />;
 };
 
+const sampleProject = (() => {
+  const {subject, date, category, id, links, skills, summary, thumbnail} =
+    createProjectDocsMock(1)[0];
+  return {subject, date, category, id, links, skills, summary, thumbnail};
+})();
+
 export const Default = Template.bind({});
-Default.args = {
-  ...createProjectDocsMock(1)[0],
-};
+Default.args = {...sampleProject};

--- a/src/projects/components/ProjectInfo/index.tsx
+++ b/src/projects/components/ProjectInfo/index.tsx
@@ -43,7 +43,7 @@ const ProjectInfo: React.FC<ProjectInfoProps> = ({
         return;
       }
       return (
-        <CustomLink key={idx} href={href}>
+        <CustomLink key={idx} href={href} defaultStyle>
           {text}
         </CustomLink>
       );

--- a/src/projects/components/ProjectList/index.tsx
+++ b/src/projects/components/ProjectList/index.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image';
-import Link from 'next/link';
 
-import {commonBlurDataURL, CssProp, ProjectDocument, systemCss} from '@src/shared';
+import {commonBlurDataURL, CssProp, CustomLink, ProjectDocument, systemCss} from '@src/shared';
 
 export interface ProjectListProps {
   projectDocs: ProjectDocument[];
@@ -13,33 +12,30 @@ const ProjectList: React.FC<ProjectListProps> = ({projectDocs, ...props}) => {
       {projectDocs.map(({id, subject, summary, thumbnail}, idx) => {
         return (
           <li key={idx} css={itemCss}>
-            <Link href={`/projects/${id}`} passHref legacyBehavior>
-              <a css={linkCss}>
-                <div css={thumbnailBoxCss(thumbnail ? 'cover' : 'contain')}>
-                  <Image
-                    src={thumbnail || '/no-pictures.png'}
-                    alt={`${subject} (thumbnail)`}
-                    fill
-                    priority
-                    placeholder="blur"
-                    blurDataURL={commonBlurDataURL}
-                  />
+            <CustomLink css={linkCss} href={`/projects/${id}`}>
+              <div css={thumbnailBoxCss(thumbnail ? 'cover' : 'contain')}>
+                <Image
+                  src={thumbnail || '/no-pictures.png'}
+                  alt={`${subject} (thumbnail)`}
+                  fill
+                  priority
+                  placeholder="blur"
+                  blurDataURL={commonBlurDataURL}
+                />
+              </div>
+              <dl css={textListCss}>
+                <div css={textItemCss}>
+                  <dt>Subject</dt>
+                  <dd>{subject}</dd>
                 </div>
-
-                <dl css={textListCss}>
+                {summary && (
                   <div css={textItemCss}>
-                    <dt>Subject</dt>
-                    <dd>{subject}</dd>
+                    <dt>Summary</dt>
+                    <dd>{summary}</dd>
                   </div>
-                  {summary && (
-                    <div css={textItemCss}>
-                      <dt>Summary</dt>
-                      <dd>{summary}</dd>
-                    </div>
-                  )}
-                </dl>
-              </a>
-            </Link>
+                )}
+              </dl>
+            </CustomLink>
           </li>
         );
       })}

--- a/src/resume/components/ResumeInfo/index.tsx
+++ b/src/resume/components/ResumeInfo/index.tsx
@@ -37,7 +37,7 @@ const ResumeInfo: React.FC<ResumeInfoProps> = ({
           {job}
         </Typography>
         {email && (
-          <CustomLink href={`mailto:${email}`} disableStyle>
+          <CustomLink href={`mailto:${email}`}>
             <Typography color="gray" fontSize="p14">
               {email}
             </Typography>

--- a/src/shared/components/CustomLink/index.stories.tsx
+++ b/src/shared/components/CustomLink/index.stories.tsx
@@ -15,14 +15,23 @@ const Template: ComponentStory<typeof CustomLink> = (args) => {
   return <CustomLink {...args} />;
 };
 
-export const Default = Template.bind({});
-Default.args = {
+export const Internal = Template.bind({});
+Internal.args = {
   href: '/',
   children: "Internal link(root('/'))",
+  defaultStyle: false,
 };
 
 export const External = Template.bind({});
 External.args = {
   href: 'https://www.google.com/',
   children: 'External link(google)',
+  defaultStyle: false,
+};
+
+export const Notion_link_style = Template.bind({});
+Notion_link_style.args = {
+  href: '/',
+  children: 'Notion link style',
+  defaultStyle: true,
 };

--- a/src/shared/components/CustomLink/index.tsx
+++ b/src/shared/components/CustomLink/index.tsx
@@ -1,19 +1,20 @@
-import {useMemo, PropsWithChildren} from 'react';
+import {useMemo, ComponentProps, PropsWithChildren} from 'react';
 
 import Link from 'next/link';
 import {rgba} from 'polished';
 
 import {CssProp, systemCss} from '../../system';
 
-export interface CustomLinkProps extends PropsWithChildren {
+export interface CustomLinkProps extends PropsWithChildren, ComponentProps<'a'> {
   href: string;
-  disableStyle?: boolean;
+  /** Apply a notion link style. */
+  defaultStyle?: boolean;
 }
 
 const isExternalLink = (href: string) => /^http/.test(href);
 const isMailto = (href: string) => /^mailto/.test(href);
 
-const CustomLink: React.FC<CustomLinkProps> = ({href, children, disableStyle, ...props}) => {
+const CustomLink: React.FC<CustomLinkProps> = ({href, defaultStyle, children, ...props}) => {
   const isNotInternal = useMemo(() => {
     return isExternalLink(href) || isMailto(href);
   }, [href]);
@@ -21,14 +22,14 @@ const CustomLink: React.FC<CustomLinkProps> = ({href, children, disableStyle, ..
   if (isNotInternal) {
     const anchorProps = isExternalLink(href) ? {rel: 'noreferrer', target: '_blank'} : undefined;
     return (
-      <a css={disableStyle || linkCss} href={href} {...anchorProps} {...props}>
+      <a css={defaultStyle && defaultCss} href={href} {...anchorProps} {...props}>
         {children}
       </a>
     );
   }
   return (
     <Link href={href} passHref legacyBehavior>
-      <a css={disableStyle || linkCss} {...props}>
+      <a css={defaultStyle && defaultCss} {...props}>
         {children}
       </a>
     </Link>
@@ -37,7 +38,7 @@ const CustomLink: React.FC<CustomLinkProps> = ({href, children, disableStyle, ..
 
 export default CustomLink;
 
-const linkCss: CssProp = (theme) =>
+const defaultCss: CssProp = (theme) =>
   systemCss({
     color: theme.colors.gray500,
     borderBottom: `1px solid ${rgba(theme.colors.gray500, 0.5)}`,

--- a/src/shared/components/Footer/index.tsx
+++ b/src/shared/components/Footer/index.tsx
@@ -35,12 +35,7 @@ const Footer: React.FC<FooterProps> = ({author, contact, ...props}) => {
             }
             return (
               <li key={key}>
-                <CustomLink
-                  css={contactLinkCss}
-                  href={value}
-                  disableStyle
-                  aria-label={`${key} icon (link)`}
-                >
+                <CustomLink css={contactLinkCss} href={value} aria-label={`${key} icon (link)`}>
                   {iconNode}
                 </CustomLink>
               </li>

--- a/src/shared/components/Header/index.tsx
+++ b/src/shared/components/Header/index.tsx
@@ -1,11 +1,11 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import Image from 'next/image';
-import Link from 'next/link';
 import {useRouter} from 'next/router';
 import {GiHamburgerMenu} from 'react-icons/gi';
 import {CSSTransition} from 'react-transition-group';
 
+import {CustomLink} from '../../components';
 import {commonBlurDataURL} from '../../constants';
 import {changeFirstCharUpperCase} from '../../functions';
 import {useMedia, useScrollDirection, ScrollDirection} from '../../hooks';
@@ -70,9 +70,9 @@ const Header: React.FC<HeaderProps> = ({profileImage, linkNames, ...props}) => {
       }
       return (
         <li key={name} css={menuItemCss}>
-          <Link href={link} passHref legacyBehavior>
-            <a onClick={handleLinkClick}>{displayName}</a>
-          </Link>
+          <CustomLink href={link} onClick={handleLinkClick}>
+            {displayName}
+          </CustomLink>
         </li>
       );
     });
@@ -120,22 +120,20 @@ const Header: React.FC<HeaderProps> = ({profileImage, linkNames, ...props}) => {
               )}
             </div>
             {/* PROFILE */}
-            <Link
+            <CustomLink
+              css={profileImageBoxCss}
               href={links.find(({name}) => name === 'home')?.link ?? '/'}
-              passHref
-              legacyBehavior
+              onClick={handleLinkClick}
             >
-              <a css={profileImageBoxCss} onClick={handleLinkClick}>
-                <Image
-                  src={profileImage}
-                  alt="profile_image"
-                  fill
-                  priority
-                  placeholder="blur"
-                  blurDataURL={commonBlurDataURL}
-                />
-              </a>
-            </Link>
+              <Image
+                src={profileImage}
+                alt="profile_image"
+                fill
+                priority
+                placeholder="blur"
+                blurDataURL={commonBlurDataURL}
+              />
+            </CustomLink>
           </div>
         </header>
       </CSSTransition>

--- a/src/shared/components/MarkdownRenderer/index.stories.tsx
+++ b/src/shared/components/MarkdownRenderer/index.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {ComponentStory, ComponentMeta} from '@storybook/react';
 
 import MarkdownRenderer from '.';
-import {sampleContentHtml, samplePrismHtml} from '../../mocks';
+import {codeblock, sampleCustomComponents, sampleMarkdown} from '../../mocks';
 
 const storyDefault = {
   title: 'components/shared/MarkdownRenderer',
@@ -12,11 +12,12 @@ const storyDefault = {
 
 export default storyDefault;
 
-const Template: ComponentStory<typeof MarkdownRenderer> = (args) => {
-  return <MarkdownRenderer {...args} />;
+const Template: ComponentStory<typeof MarkdownRenderer> = ({content, ...args}) => {
+  return <MarkdownRenderer {...args} content={content} />;
 };
 
 export const Default = Template.bind({});
-Default.args = {
-  content: `${sampleContentHtml}${samplePrismHtml}`,
-};
+Default.args = {content: `${sampleMarkdown}\n${codeblock}`};
+
+export const CustomComponents = Template.bind({});
+CustomComponents.args = {content: sampleCustomComponents};

--- a/src/shared/components/MarkdownRenderer/index.tsx
+++ b/src/shared/components/MarkdownRenderer/index.tsx
@@ -3,8 +3,6 @@ import {ForwardedRef, forwardRef, Fragment, useEffect, useMemo, useState} from '
 import {MDXRemote, MDXRemoteSerializeResult} from 'next-mdx-remote';
 import {rgba} from 'polished';
 
-import {markdownToHtml} from '@src/lib';
-
 import {
   CustomCode,
   CustomLink,
@@ -13,6 +11,7 @@ import {
   Typography,
   TypographyProps,
 } from '../../components';
+import {markdownToHtml} from '../../functions';
 import {CssProp, systemCss} from '../../system';
 
 export interface MarkdownRendererProps {
@@ -28,7 +27,7 @@ const MarkdownRenderer = (
   useEffect(() => {
     const updateContent = async () => {
       if (typeof content !== 'string') {
-        return;
+        return setFinalContent(content);
       }
       const convertedContent = await markdownToHtml(content);
       setFinalContent(convertedContent);

--- a/src/shared/components/MarkdownRenderer/index.tsx
+++ b/src/shared/components/MarkdownRenderer/index.tsx
@@ -48,7 +48,11 @@ const MarkdownRenderer = (
       <MDXRemote
         {...finalContent}
         components={{
-          a: ({href, children}) => <CustomLink href={href ?? ''}>{children}</CustomLink>,
+          a: ({href, children}) => (
+            <CustomLink href={href ?? ''} defaultStyle>
+              {children}
+            </CustomLink>
+          ),
           CustomLink,
           CustomCode,
           Typography: ({...props}: TypographyProps) => <Typography {...props} useHeadingId />,

--- a/src/shared/components/MarkdownRenderer/index.tsx
+++ b/src/shared/components/MarkdownRenderer/index.tsx
@@ -22,22 +22,27 @@ const MarkdownRenderer = (
   {content, ...props}: MarkdownRendererProps,
   ref?: ForwardedRef<HTMLDivElement>,
 ) => {
-  const [finalContent, setFinalContent] = useState(content);
+  const [tempContent, setTempContent] = useState(content);
+
+  const finalContent = useMemo(() => {
+    if (typeof content === 'string') {
+      return tempContent;
+    }
+    return content;
+  }, [content, tempContent]);
 
   useEffect(() => {
-    const updateContent = async () => {
-      if (typeof content !== 'string') {
-        return setFinalContent(content);
-      }
-      const convertedContent = await markdownToHtml(content);
-      setFinalContent(convertedContent);
+    const updateTempContent = async () => {
+      if (typeof content !== 'string') return;
+      setTempContent(await markdownToHtml(content));
     };
-    updateContent();
+    updateTempContent();
   }, [content]);
 
   if (typeof finalContent === 'string') {
     return null;
   }
+
   return (
     <div ref={ref} css={[containerCss, codeCss]} {...props}>
       <MDXRemote

--- a/src/shared/functions/index.ts
+++ b/src/shared/functions/index.ts
@@ -1,2 +1,3 @@
 export * from './date';
+export * from './markdown';
 export * from './utils';

--- a/src/shared/functions/markdown.ts
+++ b/src/shared/functions/markdown.ts
@@ -1,0 +1,14 @@
+// @ts-ignore
+import mdxPrism from 'mdx-prism';
+import {serialize} from 'next-mdx-remote/serialize';
+import rehypeSlug from 'rehype-slug';
+import remarkGfm from 'remark-gfm';
+import remarkHtml from 'remark-html';
+
+/** [async] Markdown Text -> HTML 변환 (MDX 포함) */
+export const markdownToHtml = async (aMarkdown: string) => {
+  const result = await serialize(aMarkdown, {
+    mdxOptions: {remarkPlugins: [remarkGfm, remarkHtml], rehypePlugins: [rehypeSlug, mdxPrism]},
+  });
+  return result;
+};

--- a/src/shared/mocks/constants.ts
+++ b/src/shared/mocks/constants.ts
@@ -1,131 +1,104 @@
 import {PostDocument, ProjectDocument} from '../types';
 
-/* POST ==================================================== */
-export const sampleContentHtml = `<h1>> Headings</h1>
-<h1>h1</h1>
-<h2>h2</h2>
-<h3>h3</h3>
-<h4>h4</h4>
-<h5>h5</h5>
-<h6>h6</h6>
-<h1>> Texts &#x26; code &#x26; hr &#x26; anchor</h1>
-<p><strong>bold</strong></p>
-<p><em>italic</em></p>
-<p><del>strikethrough</del></p>
-<p><code>code</code></p>
-<hr>
-<p><a href="about:blank">Anchor (about:blank)</a></p>
-<h1>> Contents</h1>
-<p>We recommend using <strong>Static Generation</strong> (with and without data) whenever possible because your page can be built once and served by CDN, which makes it much faster than having a <del>server</del> render the page <em>on</em> every request</p>
-<p>You can use <strong><em>Static Generation</em></strong> for many types of pages, including:</p>
-<ul>
-<li>Marketing pages
-<ul>
-<li>pages
-<ul>
-<li><code>pages</code></li>
-</ul>
-</li>
-</ul>
-</li>
-</ul>
-<ol>
-<li>Blog posts</li>
-<li>posts</li>
-<li>test</li>
-</ol>
-<ul>
-<li>E-commerce product listings</li>
-<li>Help and documentation</li>
-</ul>
-<h1>> Table</h1>
-<table>
-<thead>
-<tr>
-<th>th 1</th>
-<th>th 2</th>
-<th>th 3</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>td 1</td>
-<td>td 2</td>
-<td>td 3</td>
-</tr>
-<tr>
-<td>td 1</td>
-<td>td 2</td>
-<td>td 3</td>
-</tr>
-<tr>
-<td>td 1</td>
-<td>td 2</td>
-<td>td 3</td>
-</tr>
-<tr>
-<td>td 1</td>
-<td>td 2</td>
-<td>td 3</td>
-</tr>
-</tbody>
-</table>
-<h1>> Blockquote</h1>
-<blockquote>
-<p>Blockquote??</p>
-<blockquote>
-<p>inner Blockquote??</p>
-<blockquote>
-<p>inner inner Blockquote??</p>
-</blockquote>
-</blockquote>
-</blockquote>`;
+export const headings = `# > Headings\n
+# h1\n
+## h2\n
+### h3\n
+#### h4\n
+##### h5\n
+###### h6\n`;
 
-export const samplePrismHtml = `<h1>> Code Block</h1>
-<div class="remark-highlight"><pre class="language-js"><code class="language-js"><span class="token keyword">const</span> num <span class="token operator">=</span> <span class="token number">1</span><span class="token punctuation">;</span>
-<span class="token keyword">const</span> str <span class="token operator">=</span> <span class="token string">'1'</span><span class="token punctuation">;</span>
-<span class="token keyword">function</span> <span class="token function">func</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
-  <span class="token keyword">const</span> result <span class="token operator">=</span> <span class="token punctuation">[</span><span class="token punctuation">]</span><span class="token punctuation">;</span>
-  result<span class="token punctuation">.</span><span class="token method function property-access">push</span><span class="token punctuation">(</span><span class="token number">1</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
-  <span class="token keyword control-flow">return</span> result<span class="token punctuation">;</span>
-<span class="token punctuation">}</span>
-</code></pre></div>`;
+export const textCodeHrAnchor = `# > Texts & code & hr & anchor\n
+**bold**\n
+_italic_\n
+~~strikethrough~~\n
+\`code\`\n
+---\n
+[Anchor (about:blank)](about:blank)\n`;
 
-export const tempPosts: Omit<PostDocument, 'id' | 'category' | 'date'>[] = [
+export const contents = `# > Contents\n
+We recommend using **Static Generation** (with and without data) whenever possible because your page can be built once and served by CDN, which makes it much faster than having a ~~server~~ render the page _on_ every request\n
+You can use **_Static Generation_** for many types of pages, including:\n
+  - Marketing pages
+    - pages
+      - \`pages\`
+  1. Blog posts
+  2. posts
+  3. test
+  - E-commerce product listings
+  - Help and documentation\n`;
+
+export const table = `# > Table\n
+| th 1 | th 2 | th 3 |
+| ---- | ---- | ---- |
+| td 1 | td 2 | td 3 |
+| td 1 | td 2 | td 3 |
+| td 1 | td 2 | td 3 |
+| td 1 | td 2 | td 3 |\n`;
+
+export const blockquote = `# > Blockquote\n
+> Blockquote??
+>
+> > inner Blockquote??
+> >
+> > > inner inner Blockquote??\n`;
+
+export const codeblock = `# > Code Block\n
+\`\`\`js
+const num = 1;
+const str = '1';
+function func() {
+  const result = [];
+  result.push(1);
+  return result;
+}
+\`\`\`\n`;
+
+export const sampleCustomComponents = `<Typography variant="h3" backgroundColor="gray">Heading3 (Typography)</Typography>
+<br/>
+<CustomCode color="blue">BlueCode</CustomCode>
+<br/>
+<Divider height="1rem" color="gray300">Divider</Divider>
+<br/>
+<Typography variant="div" fontSize="p15">
+  <FlexBox gap="0.25rem" flexWrap="wrap">
+    {Array.from({length: 10}).map((_, idx) => (
+      <CustomCode key={idx} color="gray">
+        <span>FlexBox Item_{idx}</span>
+      </CustomCode>
+    ))}
+  </FlexBox>
+</Typography>
+\n`;
+
+export const sampleMarkdown = [headings, textCodeHrAnchor, contents, table, blockquote].join('\n');
+
+// --------------------------------
+
+export const samplePosts: Omit<PostDocument, 'id' | 'category' | 'date'>[] = [
   {
+    content: sampleMarkdown,
     subject: 'Fusce suscipit lorem',
-    content: sampleContentHtml,
-    extension: '.md',
   },
   {
+    content: `${sampleMarkdown}\n${codeblock}`,
     subject: 'dolor sit amet',
-    content: `${sampleContentHtml}${samplePrismHtml}`,
     thumbnail: '/sample.jpg',
-    extension: '.md',
   },
 ];
 
-/* PROJECT ==================================================== */
-
-export const sampleCompiledSourceHtml =
-  '/*@jsxRuntime automatic @jsxImportSource react*/\nconst {Fragment: _Fragment, jsx: _jsx, jsxs: _jsxs} = arguments[0];\nconst {useMDXComponents: _provideComponents} = arguments[0];\nfunction _createMdxContent(props) {\n  const _components = Object.assign({\n    p: "p",\n    ul: "ul",\n    li: "li",\n    pre: "pre",\n    code: "code",\n    span: "span"\n  }, _provideComponents(), props.components), {Typography, CustomCode, Divider} = _components;\n  if (!CustomCode) _missingMdxReference("CustomCode", true, "14:3-14:58");\n  if (!Divider) _missingMdxReference("Divider", true, "16:1-16:46");\n  if (!Typography) _missingMdxReference("Typography", true, "2:1-4:14");\n  return _jsxs(_Fragment, {\n    children: [_jsx(Typography, {\n      backgroundColor: "gray",\n      variant: "h3",\n      children: _jsx(_components.p, {\n        children: "🧚🏻 ⚙️ backgroundColor_Green Text (Typography Component, h3)"\n      })\n    }), "\\n", _jsxs(_components.ul, {\n      children: ["\\n", _jsx(_components.li, {\n        children: "One"\n      }), "\\n", _jsx(_components.li, {\n        children: "Two"\n      }), "\\n", _jsx(_components.li, {\n        children: "Three"\n      }), "\\n"]\n    }), "\\n", _jsx(Typography, {\n      backgroundColor: "gray",\n      variant: "h3",\n      children: _jsx(_components.p, {\n        children: "⚙️ backgroundColor_Gray Text (Typography Component, h3)"\n      })\n    }), "\\n", _jsxs(_components.ul, {\n      children: ["\\n", _jsxs(_components.li, {\n        children: ["\\n", _jsx(CustomCode, {\n          color: "orange",\n          children: "I am CustomCode"\n        }), "\\n"]\n      }), "\\n"]\n    }), "\\n", _jsx(Divider, {\n      height: "2rem",\n      children: "I am Divider"\n    }), "\\n", _jsx("br", {}), "\\n", _jsx(_components.pre, {\n      className: "language-js",\n      children: _jsxs(_components.code, {\n        className: "language-js",\n        children: [_jsx(_components.span, {\n          className: "token keyword",\n          children: "const"\n        }), " one ", _jsx(_components.span, {\n          className: "token operator",\n          children: "="\n        }), " ", _jsx(_components.span, {\n          className: "token number",\n          children: "1"\n        }), _jsx(_components.span, {\n          className: "token punctuation",\n          children: ";"\n        }), "\\n", _jsx(_components.span, {\n          className: "token keyword",\n          children: "const"\n        }), " two ", _jsx(_components.span, {\n          className: "token operator",\n          children: "="\n        }), " ", _jsx(_components.span, {\n          className: "token number",\n          children: "2"\n        }), _jsx(_components.span, {\n          className: "token punctuation",\n          children: ";"\n        }), "\\n", _jsx(_components.span, {\n          className: "token console class-name",\n          children: "console"\n        }), _jsx(_components.span, {\n          className: "token punctuation",\n          children: "."\n        }), _jsx(_components.span, {\n          className: "token method function property-access",\n          children: "log"\n        }), _jsx(_components.span, {\n          className: "token punctuation",\n          children: "("\n        }), "one ", _jsx(_components.span, {\n          className: "token operator",\n          children: "+"\n        }), " two ", _jsx(_components.span, {\n          className: "token operator",\n          children: "==="\n        }), " ", _jsx(_components.span, {\n          className: "token number",\n          children: "3"\n        }), _jsx(_components.span, {\n          className: "token punctuation",\n          children: ")"\n        }), _jsx(_components.span, {\n          className: "token punctuation",\n          children: ";"\n        }), "\\n", _jsx(_components.span, {\n          className: "token keyword",\n          children: "const"\n        }), " js ", _jsx(_components.span, {\n          className: "token operator",\n          children: "="\n        }), " ", _jsx(_components.span, {\n          className: "token string",\n          children: "\'is good!\'"\n        }), _jsx(_components.span, {\n          className: "token punctuation",\n          children: ";"\n        }), "\\n"]\n      })\n    })]\n  });\n}\nfunction MDXContent(props = {}) {\n  const {wrapper: MDXLayout} = Object.assign({}, _provideComponents(), props.components);\n  return MDXLayout ? _jsx(MDXLayout, Object.assign({}, props, {\n    children: _jsx(_createMdxContent, props)\n  })) : _createMdxContent(props);\n}\nreturn {\n  default: MDXContent\n};\nfunction _missingMdxReference(id, component, place) {\n  throw new Error("Expected " + (component ? "component" : "object") + " `" + id + "` to be defined: you likely forgot to import, pass, or provide it." + (place ? "\\nIt’s referenced in your code at `" + place + "`" : ""));\n}\n';
-
-export const sampleMDXData = {compiledSource: sampleCompiledSourceHtml, frontmatter: {}, scope: {}};
-
-export const tempProjects: Omit<ProjectDocument, 'id' | 'category' | 'date'>[] = [
+export const sampleProjects: Omit<ProjectDocument, 'id' | 'category' | 'date'>[] = [
   {
+    content: sampleMarkdown,
+    subject: 'THE SAMPLE PROJECT',
+    thumbnail: '/sample.jpg',
+  },
+  {
+    content: `${sampleMarkdown}\n${codeblock}`,
+    subject: 'Sample Project',
     links: [
       {text: 'Internal', href: '/'},
       {text: 'External(Naver)', href: 'https://www.naver.com/'},
     ],
-    subject: 'Sample Project (MDX)',
-    content: sampleMDXData,
-    extension: '.mdx',
-  },
-  {
-    subject: 'THE SAMPLE MDX',
-    content: sampleMDXData,
-    extension: '.mdx',
-    thumbnail: '/sample.jpg',
   },
 ];

--- a/src/shared/mocks/functions.ts
+++ b/src/shared/mocks/functions.ts
@@ -1,11 +1,11 @@
 import {createRandomDate} from '../functions';
 import {PostDocument, ProjectDocument} from '../types';
-import {tempPosts, tempProjects} from './constants';
+import {samplePosts, sampleProjects} from './constants';
 
 /** Mock 데이터 생성 (Posts) */
 export const createPostDocsMock = (mockLength: number = 10) => {
-  const tempCategories = ['SAMPLE', 'JavaScript', 'JUST', 'DO IT', 'React'];
   const createCategory = () => {
+    const tempCategories = ['SAMPLE', 'JavaScript', 'JUST', 'DO IT', 'React'];
     const randomCategoryType = ['string', 'string[]', 'undefined'][Math.floor(Math.random() * 3)];
     if (randomCategoryType === 'string') {
       return tempCategories[Math.floor(Math.random() * tempCategories.length)];
@@ -26,7 +26,7 @@ export const createPostDocsMock = (mockLength: number = 10) => {
   };
 
   const result: PostDocument[] = Array.from({length: mockLength}).map((_, i) => {
-    const post = tempPosts[Math.round(Math.random())];
+    const post = samplePosts[Math.round(Math.random())];
     const summary = Boolean(Math.round(Math.random()))
       ? `${post.subject}'s summary (idx: ${i})`
       : undefined;
@@ -78,7 +78,7 @@ export const createProjectDocsMock = (mockLength: number = 10) => {
   };
 
   const result: ProjectDocument[] = Array.from({length: mockLength}).map((_, i) => {
-    const projectDoc = tempProjects[Math.round(Math.random())];
+    const projectDoc = sampleProjects[Math.round(Math.random())];
     const summary = Boolean(Math.round(Math.random()))
       ? `${projectDoc.subject}'s summary (idx: ${i})`
       : undefined;
@@ -88,6 +88,7 @@ export const createProjectDocsMock = (mockLength: number = 10) => {
     };
     const startDate = createRandomDate(new Date(2019, 0, 1), new Date());
     const endDate = createRandomDate(startDate, new Date()).toString();
+
     return {
       ...projectDoc,
       category,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,11 +3060,6 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
-
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz"
@@ -3830,7 +3825,7 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abab@^2.0.3, abab@^2.0.5, abab@^2.0.6:
+abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
@@ -3842,14 +3837,6 @@ accepts@~1.3.5, accepts@~1.3.8:
   dependencies:
     mime-types "~2.1.34"
     negotiator "0.6.3"
-
-acorn-globals@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz"
-  integrity sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
-  dependencies:
-    acorn "^7.1.1"
-    acorn-walk "^7.1.1"
 
 acorn-globals@^7.0.0:
   version "7.0.1"
@@ -3869,7 +3856,7 @@ acorn-jsx@^5.0.0, acorn-jsx@^5.3.1, acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^7.1.1, acorn-walk@^7.2.0:
+acorn-walk@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
@@ -3884,12 +3871,12 @@ acorn@^6.4.1:
   resolved "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.1.1, acorn@^7.4.1:
+acorn@^7.4.1:
   version "7.4.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.0, acorn@^8.0.4, acorn@^8.1.0, acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
+acorn@^8.0.0, acorn@^8.0.4, acorn@^8.1.0, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
@@ -4632,11 +4619,6 @@ browser-assert@^1.2.1:
   resolved "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz"
   integrity sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==
 
-browser-process-hrtime@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz"
-  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
-
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
   resolved "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz"
@@ -5082,11 +5064,6 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
-
-classnames@^2.3.1:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 clean-css@^4.2.3:
   version "4.2.4"
@@ -5651,11 +5628,6 @@ css-select@^4.1.3:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
-css-selector-parser@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz"
-  integrity sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==
-
 css-what@^6.0.1:
   version "6.1.0"
   resolved "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz"
@@ -5665,11 +5637,6 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-
-cssom@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz"
-  integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
 
 cssom@^0.5.0:
   version "0.5.0"
@@ -5709,15 +5676,6 @@ damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
-
-data-urls@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz"
-  integrity sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
-  dependencies:
-    abab "^2.0.3"
-    whatwg-mimetype "^2.3.0"
-    whatwg-url "^8.0.0"
 
 data-urls@^3.0.2:
   version "3.0.2"
@@ -5759,7 +5717,7 @@ decamelize@^1.1.2:
   resolved "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
-decimal.js@^10.2.1, decimal.js@^10.4.1:
+decimal.js@^10.4.1:
   version "10.4.2"
   resolved "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz"
   integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
@@ -6048,13 +6006,6 @@ domelementtype@^2.0.1, domelementtype@^2.2.0:
   resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
-domexception@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz"
-  integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
-  dependencies:
-    webidl-conversions "^5.0.0"
-
 domexception@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz"
@@ -6335,7 +6286,7 @@ escape-goat@^2.0.0:
   resolved "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz"
   integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
 
-escape-html@^1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
@@ -7863,13 +7814,6 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
-html-encoding-sniffer@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz"
-  integrity sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==
-  dependencies:
-    whatwg-encoding "^1.0.5"
-
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz"
@@ -7980,15 +7924,6 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
-http-proxy-agent@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz"
-  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
-  dependencies:
-    "@tootallnate/once" "1"
-    agent-base "6"
-    debug "4"
-
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz"
@@ -8011,7 +7946,7 @@ https-proxy-agent@^4.0.0:
     agent-base "5"
     debug "4"
 
-https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
+https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -9290,39 +9225,6 @@ jscodeshift@^0.13.1:
     temp "^0.8.4"
     write-file-atomic "^2.3.0"
 
-jsdom@^16.5.3:
-  version "16.7.0"
-  resolved "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz"
-  integrity sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==
-  dependencies:
-    abab "^2.0.5"
-    acorn "^8.2.4"
-    acorn-globals "^6.0.0"
-    cssom "^0.4.4"
-    cssstyle "^2.3.0"
-    data-urls "^2.0.0"
-    decimal.js "^10.2.1"
-    domexception "^2.0.1"
-    escodegen "^2.0.0"
-    form-data "^3.0.0"
-    html-encoding-sniffer "^2.0.1"
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
-    is-potential-custom-element-name "^1.0.1"
-    nwsapi "^2.2.0"
-    parse5 "6.0.1"
-    saxes "^5.0.1"
-    symbol-tree "^3.2.4"
-    tough-cookie "^4.0.0"
-    w3c-hr-time "^1.0.2"
-    w3c-xmlserializer "^2.0.0"
-    webidl-conversions "^6.1.0"
-    whatwg-encoding "^1.0.5"
-    whatwg-mimetype "^2.3.0"
-    whatwg-url "^8.5.0"
-    ws "^7.4.6"
-    xml-name-validator "^3.0.0"
-
 jsdom@^20.0.0:
   version "20.0.2"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-20.0.2.tgz"
@@ -9640,7 +9542,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10976,12 +10878,12 @@ num2fraction@^1.2.2:
   resolved "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
   integrity sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==
 
-nwsapi@^2.2.0, nwsapi@^2.2.2:
+nwsapi@^2.2.2:
   version "2.2.2"
   resolved "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
-object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -11396,19 +11298,7 @@ parse-numeric-range@^0.0.2:
   resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-0.0.2.tgz#b4f09d413c7adbcd987f6e9233c7b4b210c938e4"
   integrity sha512-m6xRZuda9v6EGdnPMIkcyB3/NpdgbMJG8yPAQ0Mwm1nGlm2OE/o6YS0EAxAqv6u4/PKQPp6BNoylZnRb2U2/OA==
 
-parse-numeric-range@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz"
-  integrity sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==
-
-parse5-htmlparser2-tree-adapter@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz"
-  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
-  dependencies:
-    parse5 "^6.0.1"
-
-parse5@6.0.1, parse5@^6.0.0, parse5@^6.0.1:
+parse5@^6.0.0:
   version "6.0.1"
   resolved "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -11836,11 +11726,6 @@ pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz"
   integrity sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==
-
-prismjs@^1.23.0:
-  version "1.29.0"
-  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz"
-  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
 
 prismjs@~1.23.0:
   version "1.23.0"
@@ -12535,21 +12420,6 @@ remark-parse@^10.0.0:
     mdast-util-from-markdown "^1.0.0"
     unified "^10.0.0"
 
-remark-prism@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.npmjs.org/remark-prism/-/remark-prism-1.3.6.tgz"
-  integrity sha512-yYSXJ2MEK2DeD9UKDKFkQPcVqRx6aX2FYD1kE27ScogpZ/BBO8MoOO6gf/AKqfXvKGnP51wqvDEBmPseypgaug==
-  dependencies:
-    classnames "^2.3.1"
-    css-selector-parser "^1.4.1"
-    escape-html "^1.0.3"
-    jsdom "^16.5.3"
-    parse-numeric-range "^1.2.0"
-    parse5 "^6.0.1"
-    parse5-htmlparser2-tree-adapter "^6.0.1"
-    prismjs "^1.23.0"
-    unist-util-map "^2.0.1"
-
 remark-rehype@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-10.1.0.tgz#32dc99d2034c27ecaf2e0150d22a6dcccd9a6279"
@@ -12575,15 +12445,6 @@ remark-squeeze-paragraphs@4.0.0:
   integrity sha512-8qRqmL9F4nuLPIgl92XUuxI3pFxize+F1H0e/W3llTk0UsjJaj01+RrirkMw7P21RKe4X6goQhYRSvNWX+70Rw==
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
-
-remark-stringify@^10.0.0:
-  version "10.0.2"
-  resolved "https://registry.npmjs.org/remark-stringify/-/remark-stringify-10.0.2.tgz"
-  integrity sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-to-markdown "^1.0.0"
-    unified "^10.0.0"
 
 remark-stringify@^8.0.0:
   version "8.1.1"
@@ -12613,16 +12474,6 @@ remark@^12.0.0:
     remark-parse "^8.0.0"
     remark-stringify "^8.0.0"
     unified "^9.0.0"
-
-remark@^14.0.2:
-  version "14.0.2"
-  resolved "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz"
-  integrity sha512-A3ARm2V4BgiRXaUo5K0dRvJ1lbogrbXnhkJRmD0yw092/Yl0kOCZt1k9ZeElEwkZsWGsMumz6qL5MfNJH9nOBA==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    remark-parse "^10.0.0"
-    remark-stringify "^10.0.0"
-    unified "^10.0.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -12875,13 +12726,6 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
-
-saxes@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz"
-  integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
-  dependencies:
-    xmlchars "^2.2.0"
 
 saxes@^6.0.0:
   version "6.0.0"
@@ -13982,7 +13826,7 @@ totalist@^1.0.0:
   resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
   integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
 
-tough-cookie@^4.0.0, tough-cookie@^4.1.2:
+tough-cookie@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz"
   integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
@@ -13991,13 +13835,6 @@ tough-cookie@^4.0.0, tough-cookie@^4.1.2:
     punycode "^2.1.1"
     universalify "^0.2.0"
     url-parse "^1.5.3"
-
-tr46@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz"
-  integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
-  dependencies:
-    punycode "^2.1.1"
 
 tr46@^3.0.0:
   version "3.0.0"
@@ -14332,14 +14169,6 @@ unist-util-is@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz"
   integrity sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==
-
-unist-util-map@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/unist-util-map/-/unist-util-map-2.0.1.tgz"
-  integrity sha512-VdNvk4BQUUU9Rgr8iUOvclHa/iN9O+6Dt66FKij8l9OVezGG37gGWCPU5KSax1R2degqXFvl3kWTkvzL79e9tQ==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    object-assign "^4.0.0"
 
 unist-util-position-from-estree@^1.0.0, unist-util-position-from-estree@^1.1.0:
   version "1.1.1"
@@ -14703,20 +14532,6 @@ vm-browserify@^1.0.1, vm-browserify@^1.1.2:
   resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-w3c-hr-time@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz"
-  integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
-  dependencies:
-    browser-process-hrtime "^1.0.0"
-
-w3c-xmlserializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz"
-  integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
-  dependencies:
-    xml-name-validator "^3.0.0"
-
 w3c-xmlserializer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz"
@@ -14773,16 +14588,6 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-webidl-conversions@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz"
-  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
-
-webidl-conversions@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz"
-  integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
@@ -14933,24 +14738,12 @@ webpack@4:
     watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
-whatwg-encoding@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz"
-  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
-  dependencies:
-    iconv-lite "0.4.24"
-
 whatwg-encoding@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz"
   integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
   dependencies:
     iconv-lite "0.6.3"
-
-whatwg-mimetype@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz"
-  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
 whatwg-mimetype@^3.0.0:
   version "3.0.0"
@@ -14972,15 +14765,6 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
-
-whatwg-url@^8.0.0, whatwg-url@^8.5.0:
-  version "8.7.0"
-  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz"
-  integrity sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==
-  dependencies:
-    lodash "^4.7.0"
-    tr46 "^2.1.0"
-    webidl-conversions "^6.1.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -15124,7 +14908,7 @@ ws@^6.1.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.3.1, ws@^7.4.6:
+ws@^7.3.1:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
@@ -15145,11 +14929,6 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
-
-xml-name-validator@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz"
-  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### Summary
- MarkdownRenderer 수정
  -  `next-mdx-remote` 라이브러리가 **md**, **mdx** 모두 처리하도록 변경  
      (더 이상 사용하지 않는 `remark`, `remark-prism` 라이브러리 제거)
  - [MarkdownRenderer : Storybook](https://ranolog-storybook.vercel.app/?path=/story/components-shared-markdownrenderer--default): 마크다운 문법을 작성하여 확인할 수 있게 함
- `Link` 컴포넌트를 사용하던 모든 부분 `CustomLink` 컴포넌트로 변경
- 메인(Home) 페이지에서 **Recent Post** 클릭 시, Blog 페이지로 이동
